### PR TITLE
Codexのインストールを公式手順に更新（@openai/codex）

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -166,7 +166,7 @@ RUN fisher install oh-my-fish/theme-bobthefish
 RUN mkdir -p /home/$USER_NAME/.npm-global && \
     npm config set prefix /home/$USER_NAME/.npm-global && \
     npm install -g @anthropic-ai/claude-code && \
-    npm install -g codex-cli
+    npm install -g @openai/codex
 # copy config.fish
 COPY config.fish /home/$USER_NAME/.config/fish/config.fish
 


### PR DESCRIPTION
## 概要
- Dockerfile の Codex CLI インストール方法を公式手順に合わせて更新しました。
- npm パッケージを `codex-cli` から `@openai/codex` に変更しています。

## 背景
- 公式の配布・インストール手順に追従し、将来の互換性・保守性を高めるため。
- 既存イメージでの利用体験を変えずに、インストール元のみを正規化。

## 変更内容
- `docker/Dockerfile`
  - `npm install -g codex-cli` -> `npm install -g @openai/codex` に置換。

## 動作確認
- ローカル環境で `make test` を実行し、arm64/amd64 のマルチアーキビルドが成功（ユーザ検証済み）。
- 参考: `make test` は Buildx による bookworm ベースのイメージビルド・クリーンアップを行います。

## 影響範囲
- Docker イメージ内の Codex CLI インストールのみ。機能的な破壊的変更はありません。

## 関連
- リポジトリ運用: `AGENTS.md` / `Repository Guidelines`
- 既存の Codex 関連 PR がある場合は、マージ順序をご確認ください。

## 次のステップ
- レビュー後、Draft 解除してマージ。
- 必要に応じて README/ドキュメントの表記を `@openai/codex` に統一。